### PR TITLE
Important bug fix - double process spawning fixed

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -250,7 +250,7 @@ def run_scheduled_battle():
     try:
         #send API call to gemini
         response = client.models.generate_content(
-            model='gemini-2.5-flash-lite', #NOTE - This model should suffice
+            model='gemini-2.0-flash-lite-001', #NOTE - This model should suffice
             contents=request_content,
             config=generation_config
         )
@@ -352,4 +352,4 @@ print("!-- STARTING BATTLE LOOP... --!")
 socketio.start_background_task(battle_loop)
 
 if __name__ == '__main__':
-    socketio.run(app, debug=True, port=5000)
+    socketio.run(app, debug=True, port=5000, use_reloader=False)

--- a/backend/components/check_models.py
+++ b/backend/components/check_models.py
@@ -1,0 +1,24 @@
+import os
+from google import genai
+from dotenv import load_dotenv
+
+load_dotenv()
+API_KEY = os.getenv('GEMINI_API')
+
+client = genai.Client(api_key=API_KEY)
+
+print("Fetching available models...")
+try:
+    # We iterate and print safely
+    for model in client.models.list():
+        # Try to get the name, fallback to printing the whole object
+        name = getattr(model, 'name', 'Unknown Name')
+        display = getattr(model, 'display_name', '')
+        
+        print(f"Model ID: {name}")
+        if display:
+            print(f"Display:  {display}")
+        print("-" * 20)
+
+except Exception as e:
+    print(f"CRITICAL ERROR: {e}")


### PR DESCRIPTION
There was an issue when running the localhost that would spawn two server instances. One was the __main__ execution thread, another a Flask watcher that would auto-reload the process if you updated app.py.

This can be resolved by simply disabling the auto-reloader in __main__. Note that this does not affect production, as Gunicorn bypasses the main branch.

Another slight addition is the ability to check for available models as `components/check_models.py`. This is simply for testing and isn't hooked into any app logic.